### PR TITLE
fix some ace extraction if no extension is set

### DIFF
--- a/sflock/unpack/ace.py
+++ b/sflock/unpack/ace.py
@@ -17,7 +17,7 @@ class AceFile(Unpacker):
 
     def unpack(self, password=None, duplicates=None):
         dirpath = tempfile.mkdtemp()
-
+        original_path = self.f.filepath
         if self.f.filepath:
             if not self.f.filepath.endswith(".ace"):
                 os.rename(self.f.filepath, self.f.filepath+".ace")
@@ -36,5 +36,9 @@ class AceFile(Unpacker):
 
         if temporary:
             os.unlink(filepath)
+
+        if original_path != self.f.filepath:
+            os.rename(self.f.filepath, original_path)
+            self.f.filepath = original_path
 
         return self.process_directory(dirpath, duplicates)

--- a/sflock/unpack/ace.py
+++ b/sflock/unpack/ace.py
@@ -19,6 +19,9 @@ class AceFile(Unpacker):
         dirpath = tempfile.mkdtemp()
 
         if self.f.filepath:
+            if not self.f.filepath.endswith(".ace"):
+                os.rename(self.f.filepath, self.f.filepath+".ace")
+                self.f.filepath = self.f.filepath+".ace"
             filepath = os.path.abspath(self.f.filepath)
             temporary = False
         else:


### PR DESCRIPTION
unace-nonfree fails if no extension is set

before
```
from sflock import unpack
a = unpack("53c711d0be07be05c91b1a1e44748734ca816ac4bf91aa4b9b7a32b9b95d032f")
a.children
[]
````

now
```
>>> from sflock import unpack
>>> a = unpack("53c711d0be07be05c91b1a1e44748734ca816ac4bf91aa4b9b7a32b9b95d032f")
>>> a.children
[<sflock.abstracts.File object at 0x7f1d9f2efa10>]
```