### PR TITLE
add vhd support

### DIFF
--- a/sflock/unpack/zip7.py
+++ b/sflock/unpack/zip7.py
@@ -98,3 +98,33 @@ class LzhFile(Unpacker):
             os.unlink(filepath)
 
         return self.process_directory(dirpath, duplicates)
+
+
+
+class VHDFile(Unpacker):
+    name = "vhdfile"
+    exe = "/usr/bin/7z"
+    exts = b".vhd", b".vhdx"
+    magic = " Microsoft Disk Image"
+
+    def unpack(self, password=None, duplicates=None):
+        dirpath = tempfile.mkdtemp()
+
+        if self.f.filepath:
+            filepath = self.f.filepath
+            temporary = False
+        else:
+            filepath = self.f.temp_path(".vhd")
+            temporary = True
+
+        ret = self.zipjail(
+            filepath, dirpath, "x", "-xr![SYSTEM]*", "-o%s" % dirpath, filepath
+        )
+
+        if not ret:
+            return []
+
+        if temporary:
+            os.unlink(filepath)
+
+        return self.process_directory(dirpath, duplicates)


### PR DESCRIPTION
```
>>> from sflock import unpack
>>> q = unpack("sample.vhd") # ae554ee6d9cae636f8e887b41f61743af8804d95051775a8e4a4ec9b8bd27cbe
>>> q.to_dict()
{'password': None, 'relaname': None, 'platform': None, 'filepath': 'sample.vhd', 'package': 'vhd', 'parentdirs': [], 'filename': 'sample.vhd', 'sha256': 'ae554ee6d9cae636f8e887b41f61743af8804d95051775a8e4a4ec9b8bd27cbe', 'duplicate': False, 'extrpath': [], 'finger': {'mime': 'application/octet-stream', 'magic': 'Microsoft Disk Image, Virtual Server or Virtual PC', 'mime_human': 'octet stream', 'magic_human': 'Microsoft Disk Image (Virtual Server or Virtual PC)'}, 'error': None, 'selected': True, 'preview': False, 'relapath': None, 'type': 'container', 'children': [{'password': None, 'relaname': 'FedEx pending delivery for you.exe', 'platform': 'windows', 'filepath': None, 'package': 'exe', 'parentdirs': [], 'filename': 'FedEx pending delivery for you.exe', 'sha256': 'f500df00ac0bac4da7df838c6bbc3a5ce330cfaa26665638701ef1412570afaf', 'duplicate': False, 'extrpath': ['FedEx pending delivery for you.exe'], 'finger': {'mime': 'application/x-dosexec', 'magic': 'PE32 executable (GUI) Intel 80386, for MS Windows', 'mime_human': 'dosexec', 'magic_human': 'PE32 executable (GUI) Intel 80386 (for MS Windows)'}, 'error': None, 'selected': False, 'preview': True, 'relapath': 'FedEx pending delivery for you.exe', 'type': 'file', 'children': [], 'size': 1520128L}], 'size': 10490880}
```