### PR TITLE
Allow dependencies to be higher, non-breaking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     install_requires=[
         "click==6.6",
         "cryptography>=2.1",
-        "olefile==0.43",
+        "olefile>=0.43",
         "peepdf>=0.4.1",
-        "python-magic==0.4.12",
+        "python-magic>=0.4.12",
     ],
 )


### PR DESCRIPTION
Fixes #51.

This PR allows olefile and python-magic requirements to be fulfilled by higher, non-breaking, versions.