### PR TITLE
Add support for password-protected 7zip-archives - fixes issue #23

### DIFF
--- a/tests/test_7z.py
+++ b/tests/test_7z.py
@@ -73,21 +73,19 @@ class Test7zFile(object):
         assert len(t.children) == 1
         assert len(t.children[0].contents) == 801792
 
-    """
     def test_zip_encrypted(self):
-        assert "7-zip archive" in f("7z_encrypted.7z").magic
-        z = Zip7File(f("7z_encrypted.7z"))
+        assert "7-zip archive" in f(b"7z_encrypted.7z").magic
+        z = Zip7File(f(b"7z_encrypted.7z"))
         assert z.handles() is True
-        assert not t.f.selected
-        files = list(z.unpack("infected"))
+        assert not z.f.selected
+        files = list(z.unpack(password=b"infected"))
         assert len(files) == 1
-        assert files[0].relapath == "bar.txt"
-        assert files[0].contents == "hello world\n"
-        assert files[0].password == "infected"
+        assert files[0].relapath == b"bar.txt"
+        assert files[0].contents == b"hello world\n"
+        assert files[0].password == b"infected"
         assert files[0].magic == "ASCII text"
         assert files[0].parentdirs == []
         assert not files[0].selected
-    """
 
     def test_garbage(self):
         t = Zip7File(f(b"garbage.bin"))


### PR DESCRIPTION
This pull request adds support for unpacking password-protected 7zip-files with the help of ```zipjail```. 

It addresses [issue 23](https://github.com/hatching/sflock/issues/23) by modifying ```sflock/unpack/zip7.py``` and ```slock/abstracts.py```, so that password-protected 7z-files are handled by ```zipjail``` with the option ```--clone=1``` as described [here](https://github.com/hatching/tracy/tree/master/src/zipjail). This is needed, because ```7z``` uses up to two additional threads, when decrypting a password-protected archive. 

A testcase was added to ```tests/test_7z.py``` in order to ensure its proper working.